### PR TITLE
Add non-interactive conflict policies and per-table verbose merge statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Running the app:
 - `--conflict-policy prompt|current|incoming|merged`: Choose interactive or automatic conflict resolution behavior.
 - `--verbose-stats`: Print per-table counts for each input DB, merged counts, dedup stats, and dropped-item reasons.
 
+When using `--conflict-policy prompt`, you can optionally configure location-level source preferences at runtime (for highlights, notes, bookmarks, and input fields): choose one or more locations/publications and assign a preferred input backup file to auto-resolve conflicts for those locations.
+
 ### Example usage
 
     python jwl-backup-merger.py --folder /path/to/folder-with-jwl-backups

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Running the app:
 - `--conflict-policy prompt|current|incoming|merged`: Choose interactive or automatic conflict resolution behavior.
 - `--verbose-stats`: Print per-table counts for each input DB, merged counts, dedup stats, and dropped-item reasons.
 
-When using `--conflict-policy prompt`, you can optionally configure source preferences at runtime (for highlights, notes, bookmarks, and input fields) by publication group (`MepsLanguage + KeySymbol + IssueTagNumber`) and assign a preferred input backup file to auto-resolve conflicts for matching records.
+When using `--conflict-policy prompt`, you can optionally configure source preferences at runtime (for highlights, notes, bookmarks, and input fields) by `KeySymbol` and assign a preferred input backup file to auto-resolve conflicts for matching records.
 
 ### Example usage
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Running the app:
 
 When using `--conflict-policy prompt`, you can optionally configure source preferences at runtime (for highlights, notes, bookmarks, and input fields) by `KeySymbol` and assign a preferred input backup file to auto-resolve conflicts for matching records.
 
+In a TTY terminal, KeySymbol and file selection supports interactive keyboard navigation (arrow keys + space/enter). In non-interactive environments, it falls back to number-based prompts.
+
 ### Example usage
 
     python jwl-backup-merger.py --folder /path/to/folder-with-jwl-backups

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Running the app:
 - `--conflict-policy prompt|current|incoming|merged`: Choose interactive or automatic conflict resolution behavior.
 - `--verbose-stats`: Print per-table counts for each input DB, merged counts, dedup stats, and dropped-item reasons.
 
-When using `--conflict-policy prompt`, you can optionally configure location-level source preferences at runtime (for highlights, notes, bookmarks, and input fields): choose one or more locations/publications and assign a preferred input backup file to auto-resolve conflicts for those locations.
+When using `--conflict-policy prompt`, you can optionally configure source preferences at runtime (for highlights, notes, bookmarks, and input fields) by publication group (`MepsLanguage + KeySymbol + IssueTagNumber`) and assign a preferred input backup file to auto-resolve conflicts for matching records.
 
 ### Example usage
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ In a TTY terminal with `questionary` installed, initial confirmation prompts, Ke
 
 The merger now processes data table-by-table across all sources (instead of one source at a time), while preserving FK/PK constraints from a copied base DB.
 
+After the merge insert phase completes, the tool now runs post-merge dedupe passes on the merged DB for highlights (overlap analysis), notes (duplicate note cleanup using `LastModified` recency), and input fields (same `LocationId + TextTag`).
+
 When running in prompt mode, you can configure:
 - per-table source priority fallback order (Bookmark/InputField/Note/UserMark),
 - highlight color priority for identical-range highlight conflicts, and

--- a/README.md
+++ b/README.md
@@ -33,7 +33,16 @@ Running the app:
 
 When using `--conflict-policy prompt`, you can optionally configure source preferences at runtime (for highlights, notes, bookmarks, and input fields) by `KeySymbol` and assign a preferred input backup file to auto-resolve conflicts for matching records.
 
-In a TTY terminal with `questionary` installed, KeySymbol and file selection supports interactive keyboard navigation (arrow keys + space/enter). In non-interactive environments or when `questionary` is unavailable, it falls back to number-based prompts.
+In a TTY terminal with `questionary` installed, initial confirmation prompts, KeySymbol selection, and source-file selection all support interactive keyboard navigation (arrow keys + space/enter). In non-interactive environments or when `questionary` is unavailable, it falls back to number-based prompts.
+
+The merger now processes data table-by-table across all sources (instead of one source at a time), while preserving FK/PK constraints from a copied base DB.
+
+When running in prompt mode, you can configure:
+- per-table source priority fallback order (Bookmark/InputField/Note/UserMark),
+- highlight color priority for identical-range highlight conflicts, and
+- KeySymbol-specific source preferences.
+
+These preferences are saved to `~/.jw-backup-merger.json` and reloaded on future runs (you can still change them each run).
 
 ### Example usage
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Running the app:
 
 When using `--conflict-policy prompt`, you can optionally configure source preferences at runtime (for highlights, notes, bookmarks, and input fields) by `KeySymbol` and assign a preferred input backup file to auto-resolve conflicts for matching records.
 
-In a TTY terminal with `questionary` installed, initial confirmation prompts, KeySymbol selection, and source-file selection all support interactive keyboard navigation (arrow keys + space/enter). In non-interactive environments or when `questionary` is unavailable, it falls back to number-based prompts.
+In a TTY terminal with `questionary` installed, initial confirmation prompts, KeySymbol selection, and source-file selection all support interactive keyboard navigation (arrow keys + space/enter). For priority lists, after checkbox selection the app asks for explicit ranking so priority follows your chosen order. In non-interactive environments or when `questionary` is unavailable, it falls back to number-based prompts.
 
 The merger now processes data table-by-table across all sources (instead of one source at a time), while preserving FK/PK constraints from a copied base DB.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please note that this project is not affiliated with jw.org or the official JW L
 
 Pre-requisites:
 
-    pip install tqdm tk python-dateutil requests
+    pip install tqdm tk python-dateutil requests questionary
 
 Running the app:
 
@@ -33,7 +33,7 @@ Running the app:
 
 When using `--conflict-policy prompt`, you can optionally configure source preferences at runtime (for highlights, notes, bookmarks, and input fields) by `KeySymbol` and assign a preferred input backup file to auto-resolve conflicts for matching records.
 
-In a TTY terminal, KeySymbol and file selection supports interactive keyboard navigation (arrow keys + space/enter). In non-interactive environments, it falls back to number-based prompts.
+In a TTY terminal with `questionary` installed, KeySymbol and file selection supports interactive keyboard navigation (arrow keys + space/enter). In non-interactive environments or when `questionary` is unavailable, it falls back to number-based prompts.
 
 ### Example usage
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please note that this project is not affiliated with jw.org or the official JW L
 
 Pre-requisites:
 
-    pip install pandas tqdm tk
+    pip install tqdm tk python-dateutil requests
 
 Running the app:
 
@@ -27,7 +27,9 @@ Running the app:
 
 - `--folder FOLDER_PATH`: Folder containing JW Library backups to merge.
 - `--file FILE_PATH`: JW Library backup to add to the list of backups to merge. You can specify multiple `--file` arguments to merge multiple backups.
-- `--debug`: Enable verbose output and Excel file creation to help with debugging; also prevents deletion of temporary files.
+- `--debug`: Enable verbose output and keep temporary working files for debugging.
+- `--conflict-policy prompt|current|incoming|merged`: Choose interactive or automatic conflict resolution behavior.
+- `--verbose-stats`: Print per-table counts for each input DB, merged counts, dedup stats, and dropped-item reasons.
 
 ### Example usage
 

--- a/jw-backup-merger.py
+++ b/jw-backup-merger.py
@@ -39,6 +39,7 @@ args = parser.parse_args()
 
 selectBlockRangeSql = "SELECT BlockType, Identifier, StartToken, EndToken FROM BlockRange WHERE UserMarkId = ?"
 selectLocationSql = "SELECT DocumentId, MepsLanguage, KeySymbol, BookNumber, ChapterNumber FROM Location WHERE LocationId = ?"
+selectLocationPreferenceSql = "SELECT DocumentId, MepsLanguage, KeySymbol, IssueTagNumber, BookNumber, ChapterNumber, Track, Type, Title FROM Location WHERE LocationId = ?"
 
 
 class PExtractor(HTMLParser):
@@ -187,6 +188,7 @@ class JwlBackupProcessor:
         }
         self.table_stats = {}
         self.current_file_label = None
+        self.location_preferences = {}
 
 
     def _ensure_table_stat(self, table_target):
@@ -246,6 +248,169 @@ class JwlBackupProcessor:
                 print("  dropped items:")
                 for reason in sorted(stat["dropped"].keys()):
                     print(f"    {reason}: {stat['dropped'][reason]}")
+
+    def _location_signature_from_values(
+        self,
+        document_id,
+        meps_language,
+        keysymbol,
+        issue_tag_number,
+        book_number,
+        chapter_number,
+        track,
+        loc_type,
+    ):
+        return (
+            document_id,
+            meps_language,
+            keysymbol,
+            issue_tag_number,
+            book_number,
+            chapter_number,
+            track,
+            loc_type,
+        )
+
+    def _location_display_from_values(
+        self,
+        document_id,
+        meps_language,
+        keysymbol,
+        issue_tag_number,
+        book_number,
+        chapter_number,
+        title,
+    ):
+        parts = []
+        if title:
+            parts.append(str(title))
+        if keysymbol:
+            parts.append(str(keysymbol))
+        if issue_tag_number:
+            parts.append(str(issue_tag_number))
+        if meps_language is not None:
+            parts.append(f"Lang {meps_language}")
+        if book_number:
+            parts.append(f"Book {book_number}")
+        if chapter_number:
+            parts.append(f"Ch. {chapter_number}")
+        if not keysymbol and document_id:
+            parts.append(f"Doc {document_id}")
+        return " ".join(parts) if parts else "Unknown Location"
+
+    def _get_location_signature(self, cursor, location_id):
+        cursor.execute(selectLocationPreferenceSql, (location_id,))
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return self._location_signature_from_values(
+            row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7]
+        )
+
+    def _maybe_configure_location_preferences(self, database_files):
+        if self.conflict_policy != "prompt":
+            return
+
+        answer = input(
+            "\nDo you want to prioritize highlights/notes/bookmarks/input fields from a specific input file for specific publications/locations? (y/N): "
+        ).strip().lower()
+        if answer not in ("y", "yes"):
+            return
+
+        location_catalog = {}
+        for db_path in database_files:
+            file_label = path.basename(path.dirname(db_path)) or path.basename(db_path)
+            conn = sqlite3.connect(db_path)
+            cur = conn.cursor()
+            try:
+                cur.execute(
+                    "SELECT DocumentId, MepsLanguage, KeySymbol, IssueTagNumber, BookNumber, ChapterNumber, Track, Type, Title FROM Location"
+                )
+                for row in cur.fetchall():
+                    sig = self._location_signature_from_values(
+                        row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7]
+                    )
+                    item = location_catalog.setdefault(
+                        sig,
+                        {
+                            "display": self._location_display_from_values(
+                                row[0], row[1], row[2], row[3], row[4], row[5], row[8]
+                            ),
+                            "files": set(),
+                        },
+                    )
+                    item["files"].add(file_label)
+            finally:
+                conn.close()
+
+        if not location_catalog:
+            print("No locations found for preference selection.")
+            return
+
+        indexed_locations = sorted(
+            location_catalog.items(), key=lambda x: (x[1]["display"].lower(), str(x[0]))
+        )
+
+        print("\nAvailable locations across input files:")
+        for idx, (_, info) in enumerate(indexed_locations, 1):
+            files_str = ", ".join(sorted(info["files"]))
+            print(f"  {idx}. {info['display']}  [files: {files_str}]")
+
+        raw_selection = input(
+            "\nEnter one or more location numbers to prioritize (comma-separated), or press Enter to skip: "
+        ).strip()
+        if not raw_selection:
+            return
+
+        selected_indexes = []
+        for token in raw_selection.split(","):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                parsed = int(token)
+                if 1 <= parsed <= len(indexed_locations):
+                    selected_indexes.append(parsed)
+            except ValueError:
+                continue
+
+        selected_indexes = sorted(set(selected_indexes))
+        if not selected_indexes:
+            print("No valid locations selected. Skipping location preferences.")
+            return
+
+        for sel_idx in selected_indexes:
+            sig, info = indexed_locations[sel_idx - 1]
+            files = sorted(info["files"])
+            print(f"\nLocation: {info['display']}")
+            for i, f in enumerate(files, 1):
+                print(f"  {i}. {f}")
+
+            choice = None
+            while choice is None:
+                raw_choice = input("Choose source file number for this location: ").strip()
+                try:
+                    parsed_choice = int(raw_choice)
+                    if 1 <= parsed_choice <= len(files):
+                        choice = files[parsed_choice - 1]
+                except ValueError:
+                    pass
+
+            self.location_preferences[sig] = choice
+
+        if self.location_preferences:
+            print("\nConfigured location preferences:")
+            for sig, source_file in self.location_preferences.items():
+                print(f"  - {location_catalog[sig]['display']}: {source_file}")
+
+    def _preferred_choice_for_location(self, cursor, location_id):
+        loc_sig = self._get_location_signature(cursor, location_id)
+        if not loc_sig:
+            return None
+        preferred_file = self.location_preferences.get(loc_sig)
+        if not preferred_file:
+            return None
+        return "incoming" if self.current_file_label == preferred_file else "current"
 
     def get_table_info(self, db):
         """Get table info from database
@@ -347,7 +512,9 @@ class JwlBackupProcessor:
         merged_cursor = merged_conn.cursor()
         skipped_pks = {}
         self.pk_map = {}
-        self.current_file_label = path.basename(file_path)
+        self.current_file_label = path.basename(path.dirname(file_path)) or path.basename(
+            file_path
+        )
 
         for table_target in table_order:
             table = self.table_name_map.get(table_target.lower())
@@ -633,6 +800,33 @@ class JwlBackupProcessor:
             return next(
                 o for o in options if (o["color"], tuple(o["ranges"])) == choice_sig
             )
+
+        preferred_choice = self._preferred_choice_for_location(merged_cursor, loc_id)
+        if preferred_choice:
+            if preferred_choice == "incoming":
+                preferred_option = next(
+                    (
+                        o
+                        for o in options
+                        if any(h["source"] == "incoming" for h in o["highlights"])
+                    ),
+                    None,
+                )
+            else:
+                preferred_option = next(
+                    (
+                        o
+                        for o in options
+                        if any(h["source"] == "current" for h in o["highlights"])
+                    ),
+                    None,
+                )
+            if preferred_option:
+                print(
+                    f"  (Auto-selected by location preference: {preferred_choice} from {self.current_file_label})"
+                )
+                return preferred_option
+
         if self.conflict_policy == "current":
             choice_idx = next(
                 (
@@ -962,7 +1156,18 @@ class JwlBackupProcessor:
             )
             print(f"  Merged value: '{merged_val}'")
 
-        if self.conflict_policy == "current":
+        preferred_choice = self._preferred_choice_for_location(
+            merged_cursor, current_row.get("LocationId")
+        )
+        if preferred_choice == "incoming":
+            print(
+                f"  (Auto-selected by location preference: incoming from {self.current_file_label})"
+            )
+            choice = "i"
+        elif preferred_choice == "current":
+            print("  (Auto-selected by location preference: keep current)")
+            choice = "c"
+        elif self.conflict_policy == "current":
             choice = "c"
         elif self.conflict_policy == "incoming":
             choice = "i"
@@ -1060,6 +1265,18 @@ class JwlBackupProcessor:
         else:
             choice = self.conflict_cache["Note"].get(conflict_key, "")
 
+        preferred_choice = self._preferred_choice_for_location(
+            merged_cursor, current_row.get("LocationId")
+        )
+        if preferred_choice == "incoming":
+            print(
+                f"  (Auto-selected by location preference: incoming from {self.current_file_label})"
+            )
+            choice = "i"
+        elif preferred_choice == "current":
+            print("  (Auto-selected by location preference: keep current)")
+            choice = "c"
+
         if choice:
             print(f"  (Using previously resolved choice: {choice})")
         else:
@@ -1109,6 +1326,8 @@ class JwlBackupProcessor:
             None
         """
         merged_conn = self._initialize_merge(database_files)
+        self.location_preferences = {}
+        self._maybe_configure_location_preferences(database_files)
 
         for file_path in tqdm(database_files, desc="Merging databases"):
             self._merge_database(

--- a/jw-backup-merger.py
+++ b/jw-backup-merger.py
@@ -614,6 +614,8 @@ class JwlBackupProcessor:
                         )
                         if txt:
                             full_text.append(txt)
+                        else:
+                            full_text.append(self._format_highlight_marker(r))
                     if full_text:
                         text = " [...] ".join(full_text)
                 except Exception:
@@ -1252,6 +1254,12 @@ class JwlBackupProcessor:
             else:
                 print(line)
 
+    def _format_highlight_marker(self, block_range):
+        block_type, identifier, start_token, end_token = block_range
+        return (
+            f"[Position: block={block_type}, pid={identifier}, tokens={start_token}-{end_token}]"
+        )
+
     def get_highlighted_text(
         self,
         docid,
@@ -1423,7 +1431,7 @@ class JwlBackupProcessor:
         full_text = parser.text
 
         if not full_text:
-            return f"[Text not found for pid={identifier}]"
+            return f"[Text unavailable for pid={identifier}, tokens={start_token}-{end_token}]"
 
         # Tokenization Logic corresponding to:
         # "any word, series of chars that starts and ends with alphanumeric...

--- a/jw-backup-merger.py
+++ b/jw-backup-merger.py
@@ -660,8 +660,12 @@ class JwlBackupProcessor:
                 if not from_col:
                     continue
                 cursor.execute(
-                    f"UPDATE [{from_table}] SET [{from_col}] = ? WHERE [{from_col}] = ?",
+                    f"UPDATE OR IGNORE [{from_table}] SET [{from_col}] = ? WHERE [{from_col}] = ?",
                     (new_pk, old_pk),
+                )
+                cursor.execute(
+                    f"DELETE FROM [{from_table}] WHERE [{from_col}] = ?",
+                    (old_pk,),
                 )
 
     def _choose_highlight_winner(self, options, allow_prompt=True):


### PR DESCRIPTION
### Motivation
- Allow merges to run non-interactively with repeatable behavior and capture detailed per-table statistics to aid debugging and validation.
- Reduce false-positive duplicates for Location rows by loosening identity matching.
- Make input ordering deterministic and avoid crashes when `--file` is passed as a list.

### Description
- Added CLI options `--conflict-policy` (`prompt|current|incoming|merged`) and `--verbose-stats` and wired them into processor state for automated conflict resolution and stats control.
- Implemented table-level stats collection (`source_counts`, `new_by_file`, `duplicates_by_file`, `identical`, `dropped`, `merged_count`) and a `_print_stats` routine to output per-source and merged counts and reasons when `--verbose-stats` is set.
- Integrated stats updates into UserMark merge logic and generic table processing to count deduped/identical/new rows and to record dropped-item reasons; conflict handlers now return resolution outcomes to enable tabulation.
- Removed `Title` from `Location` identity keys to reduce false duplicates and added normalization/sorting/deduplication of input file paths plus a safer "Provided arguments" print path; updated README with new flags and dependency note.

### Testing
- Compiled the Python sources with `python -m py_compile jw-backup-merger.py dump_schema.py langs.py`, which succeeded without syntax errors.
- Executed `python jw-backup-merger.py --help`, which reported a runtime failure in this environment due to a missing third-party dependency (`ModuleNotFoundError: No module named 'dateutil'`); installing `python-dateutil` will resolve that.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990c007bc9483318b2cc7b9cf142823)