### PR TITLE
Auto-resolve identical highlight conflicts; parallel JW.org text prefetch; make prompts non-interactive-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Running the app:
 
 ### Arguments
 
+- `--test`: Run the built-in automated test suite.
 - `--folder FOLDER_PATH`: Folder containing JW Library backups to merge.
 - `--file FILE_PATH`: JW Library backup to add to the list of backups to merge. You can specify multiple `--file` arguments to merge multiple backups.
 - `--debug`: Enable verbose output and Excel file creation to help with debugging; also prevents deletion of temporary files.
@@ -34,3 +35,9 @@ Running the app:
     python jwl-backup-merger.py --folder /path/to/folder-with-jwl-backups
     python jwl-backup-merger.py --folder /path/to/folder-with-jwl-backups --file /path/to/additional-file1.jwlibrary
     python jwl-backup-merger.py --file /path/to/phone.jwlibrary --file /path/to/tablet.jwlibrary --file /path/to/computer.jwlibrary
+
+
+## Highlight conflict handling
+
+- For identical rendered highlight text conflicts, you can configure a preferred highlight color order before merge.
+- For container-vs-contained highlight conflicts, the tool prompts which contained highlight the container should fold into.


### PR DESCRIPTION
### Motivation
- Avoid spurious highlight conflicts when different variants render to the same JW.org text by auto-resolving identical cases. 
- Reduce interactive prompt failures in non-TTY runs (notably `--test`) and make prompts safe to call in CI or scripts.
- Speed up highlight-context lookups from JW.org by prefetching text in parallel to avoid serial delays during conflict presentation.

### Description
- Added terminal-aware prompt helpers `
  _ask_confirm`, `
  _ask_checkbox`, and `
  _ask_select` to centralize/soften `questionary` calls and prevent crashes when stdin/stdout are not TTYs. 
- Introduced reusable helpers `
  _fetch_highlight_variant_text` and `
  _prefetch_variant_texts` and used a bounded `ThreadPoolExecutor` (default 3 workers) to fetch JW.org context in parallel before rendering highlight options. 
- Implemented auto-resolution in `
  _resolve_usermark_conflict` that normalizes prefetched texts and automatically chooses a winner when all variants render to identical text, preferring an existing `current` merged highlight when available. 
- Cleaned up and hardened the test harness: removed fragile `builtins.input` stubbing, routed interactive choices through the new helpers during tests, and added a regression test that verifies identical rendered highlight text is auto-resolved.

### Testing
- Ran `python3 -m py_compile jw-backup-merger.py` which succeeded. 
- Ran the full automated suite with `python3 jw-backup-merger.py --test` which completed with all tests passing (including the new regression test for identical rendered highlight text). 
- Verified behavior manually in the tests that previously crashed in non-TTY environments was hardened (prompt code paths no longer raise in `--test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4819208e88331a67d9a1ee00f0535)