### PR TITLE
Enhance highlight conflict resolution: autosolve, containment-fold, prefetching, non-interactive prompts, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Running the app:
 
 ### Arguments
 
+- `--test`: Run the built-in automated test suite.
 - `--folder FOLDER_PATH`: Folder containing JW Library backups to merge.
 - `--file FILE_PATH`: JW Library backup to add to the list of backups to merge. You can specify multiple `--file` arguments to merge multiple backups.
 - `--debug`: Enable verbose output and Excel file creation to help with debugging; also prevents deletion of temporary files.
@@ -34,3 +35,9 @@ Running the app:
     python jwl-backup-merger.py --folder /path/to/folder-with-jwl-backups
     python jwl-backup-merger.py --folder /path/to/folder-with-jwl-backups --file /path/to/additional-file1.jwlibrary
     python jwl-backup-merger.py --file /path/to/phone.jwlibrary --file /path/to/tablet.jwlibrary --file /path/to/computer.jwlibrary
+
+
+## Highlight conflict handling
+
+- For identical rendered highlight text conflicts, you can configure a preferred highlight color order before merge.
+- For container-vs-contained highlight conflicts, the tool prompts which contained highlight the container should fold into.


### PR DESCRIPTION
### Motivation
- Improve merging of highlight (UserMark) conflicts by allowing deterministic autoresolve when variants render the same text and by supporting container-vs-contained folding decisions. 
- Make interactive prompts safe to run in non-interactive contexts and speed up text lookups to support automated resolution and tests. 
- Expose an automated test mode and document new usage/help in the `README.md`.

### Description
- Add a `--test` CLI flag and update `README.md` with a short note on conflict handling and the new test mode. 
- Introduce thread-based prefetching of rendered highlight text using `ThreadPoolExecutor` and a configurable `text_prefetch_workers` to speed up context fetches. 
- Add configurable highlight color priority (`color_preference`) and a `_configure_color_preference` flow to pick preferred colors for identical-text autoresolve. 
- Implement containment-detection utilities (`_range_contains`, `_ranges_contain_other_ranges`, `_option_token_bounds`, `_find_containment_parent_option`) and a containment-fold resolution path (`_resolve_containment_fold_choice`) to fold container highlights into chosen contained variants. 
- Add non-interactive-safe wrappers around questionary prompts (`_ask_confirm`, `_ask_checkbox`, `_ask_select`) and replace direct `questionary` calls so the program can default sensibly outside a TTY. 
- Autoresolve logic in `_resolve_usermark_conflict` now picks a preferred color when every option has identical rendered text and honors publication-specific `autoresolve_config` by source path. 
- Update `run_tests` to stub prompt methods rather than `builtins.input`, add tests for identical-text autoresolve and containment-fold behavior (new tests 9–11), and adapt existing tests to the new prompt wrappers.

### Testing
- Ran the built-in automated test suite via `python jw-backup-merger.py --test`, which executed tests 1–11 and completed successfully. 
- New tests verify identical rendered-text autoresolve (Test 9) and containment-fold selection and non-trigger for 2-option cases (Tests 10 and 11), and these tests passed. 
- Existing deduplication, 3-way note merge, UserMark overlap, and PK sequencing tests were re-run and passed under the updated prompt and merge logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4819208e88331a67d9a1ee00f0535)